### PR TITLE
Change add-on name to exclude Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "testpilot-ga": "^0.3.0"
   },
   "extensionManifest": {
-    "name": "Firefox Color",
+    "name": "Theme Loader for Fx Color",
     "permissions": [
       "theme",
       "storage",


### PR DESCRIPTION
This is a weird hack to pragmatically work around https://github.com/mozilla/addons/issues/690

I'm probably going to self-merge to see if it gets deployments working again.