### PR TITLE
Change "Firefox" to "Fx" only for github and local builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firefoxcolor",
-  "version": "0.0.32",
+  "version": "0.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firefoxcolor",
   "description": "Theming experiment for Firefox Quantum and beyond.",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "author": "Les Orchard <me@lmorchard.com>",
   "contributors": [
     "John Gruen <john.gruen@gmail.com>"
@@ -113,7 +113,7 @@
     "testpilot-ga": "^0.3.0"
   },
   "extensionManifest": {
-    "name": "Theme Loader for Fx Color",
+    "name": "Firefox Color",
     "permissions": [
       "theme",
       "storage",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,6 +11,8 @@ const extractCSS = new ExtractTextPlugin({
   filename: "[name].css"
 });
 
+const UNOFFICIAL_SITE_IDS = ["local", "github"];
+
 const nodeEnv = process.env.NODE_ENV || "production";
 const sitePort = process.env.PORT || "8080";
 const siteUrl = process.env.SITE_URL || `http://localhost:${sitePort}/`;
@@ -116,4 +118,11 @@ const webpackConfig = {
   }
 };
 
-module.exports = { sitePort, siteUrl, siteId, nodeEnv, webpackConfig };
+module.exports = {
+  UNOFFICIAL_SITE_IDS,
+  sitePort,
+  siteUrl,
+  siteId,
+  nodeEnv,
+  webpackConfig
+};

--- a/webpack.extension.js
+++ b/webpack.extension.js
@@ -7,7 +7,13 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const GenerateAssetWebpackPlugin = require("generate-asset-webpack-plugin");
 
 const packageMeta = require("./package.json");
-const { siteUrl, siteId, nodeEnv, webpackConfig } = require("./webpack.common.js");
+const {
+  UNOFFICIAL_SITE_IDS,
+  siteUrl,
+  siteId,
+  nodeEnv,
+  webpackConfig
+} = require("./webpack.common.js");
 
 module.exports = merge(webpackConfig, {
   entry: {
@@ -55,14 +61,21 @@ function buildManifest(compilation, cb) {
   let idSuffix = [];
   if (siteId) {
     idSuffix.push(siteId);
+    // HACK: For unofficial site IDs using AMO self-signing, remove "Firefox"
+    // https://github.com/mozilla/addons/issues/690#issuecomment-379829113
+    if (UNOFFICIAL_SITE_IDS.includes(siteId)) {
+      manifest.name = manifest.name.replace("Firefox", "Fx");
+    }
   }
   if (nodeEnv === "development") {
     idSuffix.push("dev");
   }
   if (idSuffix.length > 0) {
     idSuffix = idSuffix.join("-");
-    manifest.applications.gecko.id =
-      manifest.applications.gecko.id.replace("@", `-${idSuffix}@`);
+    manifest.applications.gecko.id = manifest.applications.gecko.id.replace(
+      "@",
+      `-${idSuffix}@`
+    );
     manifest.name = `${manifest.name} (${idSuffix})`;
   }
 


### PR DESCRIPTION
Switches back to "Firefox Color" by default, does a string replace to
change "Firefox" to "Fx" for github and local builds that self-sign
through AMO. Prod / stage using a Mozilla key shouldn't encounter the
naming issue.

Fixes #221