### PR TITLE
fix theme texture hover

### DIFF
--- a/src/web/lib/components/ThemeBackgroundPicker/index.scss
+++ b/src/web/lib/components/ThemeBackgroundPicker/index.scss
@@ -62,7 +62,7 @@
     flex: 1;
 
     &:hover {
-      box-shadow: 0 0 0 3px var(--blue-40);
+      box-shadow: inset 0 0 0 3px var(--blue-40);
     }
   }
 


### PR DESCRIPTION
fixes #236 - 'theme texture' hover clipped
- use box-shadow 'inset'