### PR TITLE
pass theme colors into presets

### DIFF
--- a/src/web/lib/components/ThemeColorsEditor/index.js
+++ b/src/web/lib/components/ThemeColorsEditor/index.js
@@ -55,10 +55,22 @@ class ThemeColorsEditor extends React.Component {
   }
 
   render() {
-    const { theme: { colors }, selectedColor } = this.props;
+    const {
+      theme: { colors },
+      selectedColor
+    } = this.props;
 
     // Select only the color properties from the theme.
     const colorKeys = Object.keys(colors).filter(name => name in colorLabels);
+
+    // Dedupe colors for swatch presets
+    const uniqueColorArray = [
+      ...new Set(
+        colorKeys.map(name => {
+          return colorToCSS(colors[name]);
+        })
+      )
+    ];
 
     return (
       <div className="theme-colors-editor">
@@ -85,7 +97,10 @@ class ThemeColorsEditor extends React.Component {
                   <SketchPicker
                     color={color}
                     disableAlpha={!colorsWithAlpha.includes(name)}
-                    onChangeComplete={color => this.handleColorChange(name, color)}
+                    onChangeComplete={color =>
+                      this.handleColorChange(name, color)
+                    }
+                    presetColors={uniqueColorArray}
                   />
                 </span>
               </li>


### PR DESCRIPTION
File this under "pulling things out of 269 to maintain coherence"

This PR changes the color picker so that preset swatches are colors already in the theme. After playing with this over a lot, i find it a lot easier to build themes with this setup.

![image](https://user-images.githubusercontent.com/3323249/39716075-4c3401c2-51fd-11e8-9357-526c4c3c8456.png)
