### PR TITLE
let tab_loading inherit color from tab_line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firefoxcolor",
   "description": "Theming experiment for Firefox Quantum and beyond.",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "author": "Les Orchard <me@lmorchard.com>",
   "contributors": [
     "John Gruen <john.gruen@gmail.com>"

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -94,6 +94,12 @@ const applyTheme = ({ theme }) => {
     newTheme.colors[key] = colorToCSS(theme.colors[key]);
   });
 
+  // TODO: we will need to actually create this field in
+  // theme manifests as part of #93.
+  if (!theme.colors.hasOwnProperty("tab_loading")) {
+    newTheme.colors.tab_loading = colorToCSS(theme.colors.tab_line);
+  }
+
   browser.theme.update(newTheme);
 };
 


### PR DESCRIPTION
Simple patch that sets the `tab_loading` to match the `tab_line` if no `tab_loading` is specified in the theme.