### PR TITLE
Set cd1 metric when add-on installed / uninstalled

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -110,6 +110,7 @@ window.addEventListener("message", ({ source, data: message }) => {
       const hasExtension = selectors.hasExtension(store.getState());
       if (!hasExtension) {
         store.dispatch(actions.ui.setHasExtension({ hasExtension: true }));
+        Metrics.setHasAddon(true);
         Metrics.installSuccess();
         postMessage("setTheme", { theme: selectors.theme(store.getState()) });
       }
@@ -132,6 +133,7 @@ setInterval(() => {
     outstandingPings++;
     if (outstandingPings >= MAX_OUTSTANDING_PINGS) {
       store.dispatch(actions.ui.setHasExtension({ hasExtension: false }));
+      Metrics.setHasAddon(false);
     }
   }
 }, PING_PERIOD);


### PR DESCRIPTION
So I saw [this issue over on Test Pilot](https://github.com/mozilla/testpilot/issues/3612) and mistook it for a Firefox Color issue. Turns out we aren't setting the add-on flag for metrics here, either. Doh.