### PR TITLE
replaced URLs for homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "private": true,
   "title": "Firefox Color",
-  "homepage": "https://mozilla.github.io/FirefoxColor/",
+  "homepage": "https://color.firefox.com",
   "main": "src/web/index.js",
   "config": {
     "development": {


### PR DESCRIPTION
The "https://mozilla.github.io/FirefoxColor/" URL is wrongly displayed instead of "https://color.firefox.com" in "about:addons",  so replaced it.

https://github.com/mozilla/FirefoxColor/issues/309