### PR TITLE
Randomize presets

### DIFF
--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -1,6 +1,7 @@
 import tinycolor from "tinycolor2";
 import { colorsWithAlpha, alphaEqualityTolerance } from "./constants";
 import { presetThemesContext, bgImages } from "./assets";
+import { shuffle } from "./utils";
 
 const defaultTheme = presetThemesContext("./default.json");
 
@@ -139,11 +140,10 @@ export const normalizeTheme = (data = {}) => {
   return theme;
 };
 
-export const presetThemes = presetThemesContext
+export const presetThemes = shuffle(presetThemesContext
   .keys()
   .map((filename, idx) => ({
     idx,
     filename,
     ...normalizeTheme(presetThemesContext(filename))
-  }))
-  .sort(({ filename: a }, { filename: b }) => a.localeCompare(b));
+  })));

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -3,3 +3,12 @@ export const DEBUG = process.env.NODE_ENV === "development";
 export const makeLog = context => (...args) =>
   // eslint-disable-next-line no-console
   DEBUG && console.log(`[FirefoxColor ${context}]`, ...args);
+
+export const shuffle = array => {
+  const arrayCopy = array.slice();
+  for (let i = arrayCopy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arrayCopy[i], arrayCopy[j]] = [arrayCopy[j], arrayCopy[i]];
+  }
+  return arrayCopy;
+};


### PR DESCRIPTION
Fixes #366: Randomize presets on first load.

Added a function to `lib/utils.js` that copies the array, shuffles it, and returns the shuffled copy.

Please LMK any thoughts!