### PR TITLE
#Fixes 249 Mouse hover over heading

### DIFF
--- a/src/web/lib/components/ThemeUrl/index.scss
+++ b/src/web/lib/components/ThemeUrl/index.scss
@@ -7,6 +7,10 @@
 
   h2 {
     margin-top: 0;
+    cursor: text;
+  }
+  p {
+    cursor: text;
   }
 
   label {

--- a/src/web/lib/components/ThemeUrl/index.scss
+++ b/src/web/lib/components/ThemeUrl/index.scss
@@ -9,6 +9,7 @@
     margin-top: 0;
     cursor: text;
   }
+  
   p {
     cursor: text;
   }

--- a/src/web/lib/components/ThemeUrl/index.scss
+++ b/src/web/lib/components/ThemeUrl/index.scss
@@ -9,7 +9,7 @@
     margin-top: 0;
     cursor: text;
   }
-  
+
   p {
     cursor: text;
   }


### PR DESCRIPTION
The mouse pointer now changes into a text select pointer on hover over "Share your theme" and the text below it, i.e., "Copy and paste this URL to share your creation."