### PR TITLE
Add start:ec2 task that auto-sets host name from AWS API

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     }
   },
   "scripts": {
-    "start": "npm-run-all --parallel server watch:extension watch:lint watch:validate watch:test",
-    "server": "cross-env NODE_ENV=development SITE_ID=local webpack-dev-server --config webpack.web.js",
+    "start": "cross-env NODE_ENV=development SITE_ID=local SITE_HOST=localhost npm run start:common",
+    "start:common": "npm-run-all --parallel server watch:extension watch:lint watch:validate watch:test",
+    "start:ec2": "cross-env HOST=$(curl -s http://169.254.169.254/latest/meta-data/public-hostname) NODE_ENV=development SITE_ID=remote npm run start:common",
+    "server": "webpack-dev-server --config webpack.web.js",
     "watch": "npm-run-all --parallel watch:*",
-    "watch:web": "cross-env NODE_ENV=development SITE_ID=local webpack --watch --progress --colors --config webpack.web.js",
-    "watch:extension": "cross-env NODE_ENV=development SITE_ID=local webpack --watch --progress --colors --config webpack.extension.js",
+    "watch:web": "webpack --watch --progress --colors --config webpack.web.js",
+    "watch:extension": "webpack --watch --progress --colors --config webpack.extension.js",
     "watch:lint": "npm-run-all --parallel watch:lint:*",
     "watch:lint:js": "onchange -p -v \"src/**/*.js\" -- npm run lint:js",
     "watch:lint:css": "onchange -p -v \"src/**/*.scss\" -- npm run lint:css",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -14,8 +14,9 @@ const extractCSS = new ExtractTextPlugin({
 const UNOFFICIAL_SITE_IDS = ["local", "github"];
 
 const nodeEnv = process.env.NODE_ENV || "production";
+const siteHost = process.env.HOST || "localhost";
 const sitePort = process.env.PORT || "8080";
-const siteUrl = process.env.SITE_URL || `http://localhost:${sitePort}/`;
+const siteUrl = process.env.SITE_URL || `http://${siteHost}:${sitePort}/`;
 const siteId = process.env.SITE_ID || "";
 const downloadFirefoxUtmSource =
   process.env.DOWNLOAD_FIREFOX_UTM_SOURCE || new url.URL(siteUrl).hostname;
@@ -125,6 +126,7 @@ const webpackConfig = {
 
 module.exports = {
   UNOFFICIAL_SITE_IDS,
+  siteHost,
   sitePort,
   siteUrl,
   siteId,

--- a/webpack.web.js
+++ b/webpack.web.js
@@ -17,6 +17,7 @@ module.exports = merge(common.webpackConfig, {
   },
   devServer: {
     contentBase: path.join(__dirname, "build/web"),
+    host: common.siteHost,
     port: common.sitePort
   },
   output: {


### PR DESCRIPTION
This ends up being handy for me to run a dev box in EC2, as well as setting HOST env var along with PORT to override defaults.