### PR TITLE
Fixes #399 : By Renaming Buttons to Standard

### DIFF
--- a/src/web/lib/components/GeneratorButtons/index.js
+++ b/src/web/lib/components/GeneratorButtons/index.js
@@ -17,10 +17,10 @@ export const GeneratorButtons = ({ setTheme, theme }) => {
   return (
     <div className="generator-buttons">
       <h2>Generate a theme</h2>
-      <button className="generator-buttons__button" title="generate complementary theme" onClick={handleComplementClick}>
+      <button className="generator-buttons__button" title="Generate complementary theme" onClick={handleComplementClick}>
         Complementary
       </button>
-      <button className="generator-buttons__button" title="generate random theme" onClick={handleRandomClick}>
+      <button className="generator-buttons__button" title="Generate random theme" onClick={handleRandomClick}>
         Random
       </button>
     </div>

--- a/src/web/lib/components/Modal/index.js
+++ b/src/web/lib/components/Modal/index.js
@@ -18,7 +18,7 @@ export const Modal = ({ toggleModal, displayModal, children }) => {
         className="modal__content"
         onClick={event => event.stopPropagation()}
       >
-        <button className="modal__toggle" title="close" onClick={handleToggle}>
+        <button className="modal__toggle" title="Close" onClick={handleToggle}>
           <img src={iconClose} alt="close icon" />
         </button>
         {children}


### PR DESCRIPTION
I've changed the text of the Button Hover ToolTips to now start with a capitalized letter, as was required in the issue description. 