### PR TITLE
Switch path to src prop for ReactSVG upgrade

### DIFF
--- a/src/web/lib/components/AppFooter/index.js
+++ b/src/web/lib/components/AppFooter/index.js
@@ -23,7 +23,7 @@ export const AppFooter = ({ hasExtension, setDisplayLegalModal }) => {
           href="https://www.mozilla.org"
           aria-label="Mozilla logo"
         >
-          <ReactSVG path={iconMoz} className="app-footer__legal-logo" />
+          <ReactSVG src={iconMoz} className="app-footer__legal-logo" />
         </a>
         <a
           className="app-footer__legal-link"
@@ -78,7 +78,7 @@ export const AppFooter = ({ hasExtension, setDisplayLegalModal }) => {
           aria-label="@FxTestPilot Twitter"
           title="Twitter"
         >
-          <ReactSVG path={iconTwitter} svgClassName="app-footer__social-logo" />
+          <ReactSVG src={iconTwitter} svgClassName="app-footer__social-logo" />
         </a>
         <a
           className="app-footer__social-link"
@@ -87,7 +87,7 @@ export const AppFooter = ({ hasExtension, setDisplayLegalModal }) => {
           aria-label="Firefox Color GitHub"
           title="GitHub"
         >
-          <ReactSVG path={iconGH} svgClassName="app-footer__social-logo" />
+          <ReactSVG src={iconGH} svgClassName="app-footer__social-logo" />
         </a>
       </nav>
     </footer>

--- a/src/web/lib/components/AppHeader/index.js
+++ b/src/web/lib/components/AppHeader/index.js
@@ -43,7 +43,7 @@ export const AppHeader = ({ theme, hasExtension }) => {
           rel="noopener noreferrer"
         >
           <span>Feedback</span>
-          <ReactSVG svgStyle={{ fill: "#fff" }} path={iconFeedback} />
+          <ReactSVG svgStyle={{ fill: "#fff" }} src={iconFeedback} />
         </a>
       )}
     </div>

--- a/src/web/lib/components/BrowserPreview/index.js
+++ b/src/web/lib/components/BrowserPreview/index.js
@@ -32,7 +32,7 @@ export const BrowserPreview = ({
       {asset && (
         <ReactSVG
           svgStyle={{ fill: colors[colorName] }}
-          path={buttonImages(`./${name}-16.svg`)}
+          src={buttonImages(`./${name}-16.svg`)}
         />
       )}
       {!asset && (


### PR DESCRIPTION
Turns out all the SVGs silently broke after the ReactSVG upgrade. This should fix.