### PR TITLE
Fixes #430: Add og:description meta-tag

### DIFF
--- a/src/web/index.html.ejs
+++ b/src/web/index.html.ejs
@@ -9,6 +9,7 @@
     <meta property="og:url" content="<%= htmlWebpackPlugin.options.homepage %>" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="<%= htmlWebpackPlugin.options.ogImage %>" />
+    <meta property="og:description" content="<%= htmlWebpackPlugin.options.description %>" />
     <!-- Twitter card meta tags-->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@FxTestPilot" />


### PR DESCRIPTION
Add og:description meta-tag to <head> tag
Use the description variable value of <meta name="description"> for the content attribute of 
<meta property="og:description">