### PR TITLE
Clear and re-render image import error state before setting new state

### DIFF
--- a/src/web/lib/components/ThemeCustomBackgroundPicker/index.js
+++ b/src/web/lib/components/ThemeCustomBackgroundPicker/index.js
@@ -361,6 +361,14 @@ class ImageImporter extends React.Component {
     });
   }
 
+  resetErrorState = cb => {
+    this.setState({
+      error: false,
+      tooLarge: false,
+      wrongType: false
+    }, cb);
+  }
+
   handleFileChoice = ev => {
     const { addImage, updateImage, onImport } = this.props;
 
@@ -371,7 +379,9 @@ class ImageImporter extends React.Component {
       wrongType: !CUSTOM_BACKGROUND_ALLOWED_TYPES.includes(file.type)
     };
     errorState.error = Object.values(errorState).filter(v => v).length > 0;
-    this.setState(errorState);
+    // HACK: Ensure a render with a cleared error state before setting
+    // the new error state, so that a new modal is animated in
+    this.resetErrorState(() => this.setState(errorState));
     if (errorState.error) {
       return;
     }


### PR DESCRIPTION
Fixes a problem where causing the same error state with successive upload
attempts would not display an error, because the same error state was still
rendered and hidden by CSS. (e.g. add two files of the wrong type, only the
first attempt results in a visible message)

Fixes #438