### PR TITLE
Bugfixes for incoming shared theme dialog

### DIFF
--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -75,6 +75,7 @@ export const selectors = {
   displayLegalModal: state => state.ui.displayLegalModal,
   displayShareModal: state => state.ui.displayShareModal,
   shouldOfferPendingTheme: state =>
+    state.ui.hasExtension &&
     !state.ui.firstRun &&
     !state.ui.userHasEdited &&
     state.ui.pendingTheme !== null &&
@@ -168,13 +169,9 @@ export const reducers = {
         ...state,
         loaderDelayExpired
       }),
-      SET_THEME: (state, { meta }) => ({
+      [combineActions(...themeChangeActions)]: (state, { meta = {} }) => ({
         ...state,
-        userHasEdited: meta && meta.userEdit ? true : state.userHasEdited
-      }),
-      [combineActions(...themeChangeActions)]: state => ({
-        ...state,
-        userHasEdited: true
+        userHasEdited: meta.userEdit ? true : state.userHasEdited
       })
     },
     {

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -229,6 +229,8 @@ if (!params.theme) {
       store.dispatch({
         ...actions.theme.setTheme({ theme }),
         meta: {
+          // This is an automatic change, not a user edit
+          userEdit: false,
           // Skip updating history for this theme, because it came from the URL
           skipHistory: true,
           // Skip updating the add-on for this theme, because it needs approval
@@ -245,5 +247,8 @@ if (!params.theme) {
       }
     })
     // If the theme decoding fails, just ignore it.
-    .catch(() => postMessage("fetchTheme"));
+    .catch(e => {
+      log("Theme decoding failed", e);
+      postMessage("fetchTheme");
+    });
 }

--- a/src/web/lib/components/App/index.js
+++ b/src/web/lib/components/App/index.js
@@ -104,8 +104,7 @@ export const AppComponent = props => {
           <Fragment>
             <div className="app">
               <AppBackground {...props} />
-              {hasExtension &&
-                shouldOfferPendingTheme && <SharedThemeDialog {...props} />}
+              {shouldOfferPendingTheme && <SharedThemeDialog {...props} />}
               <AppHeader {...props} />
               <main className="app__main">
                 <Browser


### PR DESCRIPTION
- ensure theme changes during init are not flagged as user edits, since
  the shared theme dialog will not show up after a user edit

- bugfix for userEdit meta flag in ui actions

- merge SET_THEME ui reducer into the combined theme change actions,
  since the latter was clobbering the former

- add log message for shared theme decoding failure

- add hasExtension flag to shouldOfferPendingTheme selector

Fixes #479