### PR TITLE
Change default webpack chunk filename delimiter

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -59,6 +59,17 @@ const webpackConfig = {
   resolve: {
     extensions: [".js", ".jsx"]
   },
+  optimization: {
+    splitChunks: {
+      automaticNameDelimiter: "/",
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/]/,
+          priority: 0          
+        }
+      }
+    }
+  },
   plugins: [
     new MiniCssExtractPlugin(),
     new WriteFilePlugin(),


### PR DESCRIPTION
Bugfix for builds on Windows. Should result in paths like this:
```
build/web/vendor/lib/export.chunk.js
```
Rather than this:
```
build/web/vendors~./lib/export.chunk.js
```

Fixes #521