### PR TITLE
Fixes #528 The "Replace image" and "X" buttons are now not exceeding the "Custom backgrounds" area at browser resize

### DIFF
--- a/src/web/lib/components/ThemeCustomBackgroundPicker/index.scss
+++ b/src/web/lib/components/ThemeCustomBackgroundPicker/index.scss
@@ -251,3 +251,23 @@
     }
   }
 }
+
+@media (max-width: 720px) {
+  .customBackgroundItem {
+    .align-group {
+      margin: 0;
+    }
+
+    .image-preview {
+      flex: 0;
+    }
+
+    .tiling {
+      width: 0;
+    }
+
+    .import-image {
+      min-width: 119px;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #528 The "Replace image" and "X" buttons are now not exceeding the "Custom backgrounds" area at browser resize

![screen shot 2018-10-28 at 17 43 19](https://user-images.githubusercontent.com/17615573/47615873-585d4280-dadb-11e8-897e-6420eb8ca014.png)
