### PR TITLE
Fixes #475 and #528

### DIFF
--- a/src/web/lib/components/ThemeCustomBackgroundPicker/index.js
+++ b/src/web/lib/components/ThemeCustomBackgroundPicker/index.js
@@ -279,7 +279,7 @@ class ThemeCustomBackgroundSelector extends React.Component {
 
               <ImportButton label={errors ? "Retry" : "Replace image"} />
 
-              <button className="clear" onClick={handleClearBackground} />
+              <button title={`Close`} className="clear" onClick={handleClearBackground} />
             </li>
           );
         }}

--- a/src/web/lib/components/ThemeCustomBackgroundPicker/index.scss
+++ b/src/web/lib/components/ThemeCustomBackgroundPicker/index.scss
@@ -228,6 +228,7 @@
     &:hover,
     &:focus {
       background-color: var(--grey-90-a10);
+      cursor: pointer;
     }
 
     &:active {
@@ -250,9 +251,7 @@
       display: none;
     }
   }
-}
 
-@media (max-width: 720px) {
   .customBackgroundItem {
     .align-group {
       margin: 0;


### PR DESCRIPTION
#528 : The "Replace image" and "X" buttons are not exceeding the "Custom backgrounds" area at browser resize
#475 : The "Delete" button from the "Custom Background Image" area does have hover effect and tooltip