### PR TITLE
Disable .bmp as allowed background image media type

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -15,7 +15,7 @@ export const CUSTOM_BACKGROUND_ALLOWED_TYPES = [
   "image/jpeg",
   "image/png",
   // "image/gif",
-  "image/bmp"
+  // "image/bmp"
   // "image/svg+xml"
 ];
 


### PR DESCRIPTION
(Until or unless we investigate whether this is an upstream theme API
issue)

Fixes #547