### PR TITLE
fix: update theme properties to remove usage of the deprecated lwt aliases

### DIFF
--- a/docs/theme-schema.json
+++ b/docs/theme-schema.json
@@ -79,7 +79,7 @@
                 "toolbar_field_text": {
                     "$ref": "#/definitions/rgb"
                 },
-                "bookmark_text": {
+                "toolbar_text": {
                     "$ref": "#/definitions/rgb"
                 },
                 "tab_line": {
@@ -92,7 +92,7 @@
                     "$ref": "#/definitions/rgb"
                 }
             },
-            "required": ["toolbar", "bookmark_text", "frame", "tab_background_text", "toolbar_field", "toolbar_field_text", "tab_line", "popup", "popup_text"],
+            "required": ["toolbar", "toolbar_text", "frame", "tab_background_text", "toolbar_field", "toolbar_field_text", "tab_line", "popup", "popup_text"],
             "additionalProperties": false
         },
         "images": {

--- a/docs/theme-schema.json
+++ b/docs/theme-schema.json
@@ -64,10 +64,10 @@
         "colors": {
             "type": "object",
             "properties": {
-                "accentcolor": {
+                "frame": {
                     "$ref": "#/definitions/rgb"
                 },
-                "textcolor": {
+                "tab_background_text": {
                     "$ref": "#/definitions/rgb"
                 },
                 "toolbar": {
@@ -79,7 +79,7 @@
                 "toolbar_field_text": {
                     "$ref": "#/definitions/rgb"
                 },
-                "toolbar_text": {
+                "bookmark_text": {
                     "$ref": "#/definitions/rgb"
                 },
                 "tab_line": {
@@ -92,13 +92,13 @@
                     "$ref": "#/definitions/rgb"
                 }
             },
-            "required": ["toolbar", "toolbar_text", "accentcolor", "textcolor", "toolbar_field", "toolbar_field_text", "tab_line", "popup", "popup_text"],
+            "required": ["toolbar", "bookmark_text", "frame", "tab_background_text", "toolbar_field", "toolbar_field_text", "tab_line", "popup", "popup_text"],
             "additionalProperties": false
         },
         "images": {
             "type": "object",
             "properties": {
-                "headerURL": {
+                "theme_frame": {
                     "type": "string"
                 },
                 "additional_backgrounds": {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -23,9 +23,9 @@ export const CUSTOM_BACKGROUND_DEFAULT_ALIGNMENT = "right top";
 
 export const colorLabels = {
   toolbar: "Toolbar Color",
-  toolbar_text: "Toolbar Icons and Text",
-  accentcolor: "Background Color",
-  textcolor: "Background Tab Text Color",
+  bookmark_text: "Toolbar Icons and Text",
+  frame: "Background Color",
+  tab_background_text: "Background Tab Text Color",
   toolbar_field: "Search Bar Color",
   toolbar_field_text: "Search Text",
   tab_line: "Tab Highlight Color",
@@ -35,7 +35,7 @@ export const colorLabels = {
 
 export const fallbackColors = {
   popup: "toolbar",
-  popup_text: "textcolor"
+  popup_text: "tab_background_text"
 };
 
 export const colorsWithAlpha = ["toolbar", "toolbar_field"];

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -23,7 +23,7 @@ export const CUSTOM_BACKGROUND_DEFAULT_ALIGNMENT = "right top";
 
 export const colorLabels = {
   toolbar: "Toolbar Color",
-  bookmark_text: "Toolbar Icons and Text",
+  toolbar_text: "Toolbar Icons and Text",
   frame: "Background Color",
   tab_background_text: "Background Tab Text Color",
   toolbar_field: "Search Bar Color",

--- a/src/lib/generators.js
+++ b/src/lib/generators.js
@@ -28,9 +28,9 @@ export const generateComplementaryTheme = (color = null) => {
   const complementColor = createA11yColor(seed.complement().toRgb(), baseColor);
 
   newTheme.colors.toolbar = baseColor;
-  newTheme.colors.toolbar_text = complementColor;
-  newTheme.colors.accentcolor = lightColor;
-  newTheme.colors.textcolor = complementColor;
+  newTheme.colors.bookmark_text = complementColor;
+  newTheme.colors.frame = lightColor;
+  newTheme.colors.tab_background_text = complementColor;
   newTheme.colors.toolbar_field = lightColor;
   newTheme.colors.toolbar_field_text = complementColor;
   newTheme.colors.tab_line = complementColor;

--- a/src/lib/generators.js
+++ b/src/lib/generators.js
@@ -28,7 +28,7 @@ export const generateComplementaryTheme = (color = null) => {
   const complementColor = createA11yColor(seed.complement().toRgb(), baseColor);
 
   newTheme.colors.toolbar = baseColor;
-  newTheme.colors.bookmark_text = complementColor;
+  newTheme.colors.toolbar_text = complementColor;
   newTheme.colors.frame = lightColor;
   newTheme.colors.tab_background_text = complementColor;
   newTheme.colors.toolbar_field = lightColor;

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -165,25 +165,21 @@ export const normalizeTheme = (data = {}) => {
     theme.images.custom_backgrounds = images.custom_backgrounds || [];
   }
 
+  // Fx70 update - deprecated headerURL
   if (images.headerURL) {
-  // Fx69 update - deprecate headerURL
     images.theme_frame = images.headerURL;
     const background = normalizeThemeBackground(images.theme_frame);
     if (background) {
       theme.images.additional_backgrounds = [background];
     }
   }
-  // Fx69 update - deprecate accentcolor
+  // Fx70 update - deprecated accentcolor
   if (theme.colors.accentcolor) {
     theme.colors.frame = theme.colors.accentcolor;
   }
- // Fx69 update - deprecate textcolor
+  // Fx70 update - deprecated textcolor
   if (theme.colors.textcolor) {
-    theme.colors.frame = theme.colors.textcolor;
-  }
- // Fx69 update - deprecate toolbar_text
-  if (theme.colors.toolbar_text) {
-    theme.colors.bookmark_text = theme.colors.toolbar_text;
+    theme.colors.tab_background_text = theme.colors.textcolor;
   }
 
   if (images.additional_backgrounds) {
@@ -265,7 +261,7 @@ export const convertToBrowserTheme = (theme, bgImages, customBackgrounds) => {
   }
 
   if (!theme.colors.hasOwnProperty("popup_text")) {
-    newTheme.colors.popup_text = colorToCSS(theme.colors.bookmark_text);
+    newTheme.colors.popup_text = colorToCSS(theme.colors.toolbar_text);
   }
 
   return newTheme;

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -166,10 +166,24 @@ export const normalizeTheme = (data = {}) => {
   }
 
   if (images.headerURL) {
-    const background = normalizeThemeBackground(images.headerURL);
+  // Fx69 update - deprecate headerURL
+    images.theme_frame = images.headerURL;
+    const background = normalizeThemeBackground(images.theme_frame);
     if (background) {
       theme.images.additional_backgrounds = [background];
     }
+  }
+  // Fx69 update - deprecate accentcolor
+  if (theme.colors.accentcolor) {
+    theme.colors.frame = theme.colors.accentcolor;
+  }
+ // Fx69 update - deprecate textcolor
+  if (theme.colors.textcolor) {
+    theme.colors.frame = theme.colors.textcolor;
+  }
+ // Fx69 update - deprecate toolbar_text
+  if (theme.colors.toolbar_text) {
+    theme.colors.bookmark_text = theme.colors.toolbar_text;
   }
 
   if (images.additional_backgrounds) {
@@ -247,11 +261,11 @@ export const convertToBrowserTheme = (theme, bgImages, customBackgrounds) => {
   }
 
   if (!theme.colors.hasOwnProperty("popup")) {
-    newTheme.colors.popup = colorToCSS(theme.colors.accentcolor);
+    newTheme.colors.popup = colorToCSS(theme.colors.frame);
   }
 
   if (!theme.colors.hasOwnProperty("popup_text")) {
-    newTheme.colors.popup_text = colorToCSS(theme.colors.toolbar_text);
+    newTheme.colors.popup_text = colorToCSS(theme.colors.bookmark_text);
   }
 
   return newTheme;

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -159,21 +159,22 @@ export const normalizeTheme = (data = {}) => {
   // default values.
 
   // Fx70 update - deprecated headerURL
-  if (images.headerURL) {
+  if (images.headerURL && !images.theme_frame) {
     images.theme_frame = images.headerURL;
-    delete images.headerURL;
   }
+  delete images.headerURL;
 
   // Fx70 update - deprecated accentcolor
-  if (colors.accentcolor) {
-    colors.frame = data.colors.accentcolor;
-    delete colors.accentcolor;
+  if (colors.accentcolor && !colors.frame) {
+    colors.frame = colors.accentcolor;
   }
+  delete colors.accentcolor;
+
   // Fx70 update - deprecated textcolor
-  if (colors.textcolor) {
-    colors.tab_background_text = data.colors.textcolor;
-    delete colors.textcolor;
+  if (colors.textcolor && !colors.tab_background_text) {
+    colors.tab_background_text = colors.textcolor;
   }
+  delete colors.textcolor;
 
   const theme = {
     colors: normalizeThemeColors(colors, defaultTheme.colors),

--- a/src/preset-themes/001.json
+++ b/src/preset-themes/001.json
@@ -6,7 +6,7 @@
       "b": 227,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 215,
       "g": 226,
       "b": 239

--- a/src/preset-themes/001.json
+++ b/src/preset-themes/001.json
@@ -6,17 +6,17 @@
       "b": 227,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 215,
       "g": 226,
       "b": 239
     },
-    "accentcolor": {
+    "frame": {
       "r": 115,
       "g": 214,
       "b": 228
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 84,
       "g": 84,
       "b": 84

--- a/src/preset-themes/002.json
+++ b/src/preset-themes/002.json
@@ -7,7 +7,7 @@
       "b": 84,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 67,
       "g": 194,
       "b": 218

--- a/src/preset-themes/002.json
+++ b/src/preset-themes/002.json
@@ -7,17 +7,17 @@
       "b": 84,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 67,
       "g": 194,
       "b": 218
     },
-    "accentcolor": {
+    "frame": {
       "r": 14,
       "g": 41,
       "b": 65
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 24,
       "g": 156,
       "b": 180

--- a/src/preset-themes/003.json
+++ b/src/preset-themes/003.json
@@ -6,17 +6,17 @@
       "b": 105,
       "a": 0.17
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 247,
       "g": 253,
       "b": 251
     },
-    "accentcolor": {
+    "frame": {
       "r": 157,
       "g": 183,
       "b": 190
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 255,
       "g": 255,
       "b": 255

--- a/src/preset-themes/003.json
+++ b/src/preset-themes/003.json
@@ -6,7 +6,7 @@
       "b": 105,
       "a": 0.17
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 247,
       "g": 253,
       "b": 251

--- a/src/preset-themes/004.json
+++ b/src/preset-themes/004.json
@@ -7,7 +7,7 @@
       "b": 61,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 255,
       "g": 255,
       "b": 255

--- a/src/preset-themes/004.json
+++ b/src/preset-themes/004.json
@@ -7,17 +7,17 @@
       "b": 61,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 255,
       "g": 255,
       "b": 255
     },
-    "accentcolor": {
+    "frame": {
       "r": 8,
       "g": 11,
       "b": 33
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 215,
       "g": 226,
       "b": 239

--- a/src/preset-themes/005.json
+++ b/src/preset-themes/005.json
@@ -7,7 +7,7 @@
       "b": 249,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 159,
       "g": 65,
       "b": 190

--- a/src/preset-themes/005.json
+++ b/src/preset-themes/005.json
@@ -7,17 +7,17 @@
       "b": 249,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 159,
       "g": 65,
       "b": 190
     },
-    "accentcolor": {
+    "frame": {
       "r": 223,
       "g": 182,
       "b": 246
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 159,
       "g": 65,
       "b": 190

--- a/src/preset-themes/006.json
+++ b/src/preset-themes/006.json
@@ -7,7 +7,7 @@
       "b": 247,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 185,
       "g": 17,
       "b": 223

--- a/src/preset-themes/006.json
+++ b/src/preset-themes/006.json
@@ -7,17 +7,17 @@
       "b": 247,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 185,
       "g": 17,
       "b": 223
     },
-    "accentcolor": {
+    "frame": {
       "r": 255,
       "g": 255,
       "b": 255
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 185,
       "g": 17,
       "b": 223

--- a/src/preset-themes/007.json
+++ b/src/preset-themes/007.json
@@ -7,17 +7,17 @@
       "b": 75,
       "a": 0.8
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 27,
       "g": 170,
       "b": 177
     },
-    "accentcolor": {
+    "frame": {
       "r": 22,
       "g": 54,
       "b": 75
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 148,
       "g": 157,
       "b": 173

--- a/src/preset-themes/007.json
+++ b/src/preset-themes/007.json
@@ -7,7 +7,7 @@
       "b": 75,
       "a": 0.8
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 27,
       "g": 170,
       "b": 177

--- a/src/preset-themes/008.json
+++ b/src/preset-themes/008.json
@@ -7,7 +7,7 @@
       "b": 219,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 136,
       "g": 141,
       "b": 129

--- a/src/preset-themes/008.json
+++ b/src/preset-themes/008.json
@@ -7,17 +7,17 @@
       "b": 219,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 136,
       "g": 141,
       "b": 129
     },
-    "accentcolor": {
+    "frame": {
       "r": 201,
       "g": 197,
       "b": 197
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 245,
       "g": 78,
       "b": 41

--- a/src/preset-themes/009.json
+++ b/src/preset-themes/009.json
@@ -7,7 +7,7 @@
       "b": 236,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 140,
       "g": 89,
       "b": 87

--- a/src/preset-themes/009.json
+++ b/src/preset-themes/009.json
@@ -7,17 +7,17 @@
       "b": 236,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 140,
       "g": 89,
       "b": 87
     },
-    "accentcolor": {
+    "frame": {
       "r": 243,
       "g": 223,
       "b": 223
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 140,
       "g": 89,
       "b": 87

--- a/src/preset-themes/010.json
+++ b/src/preset-themes/010.json
@@ -7,7 +7,7 @@
       "b": 252,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 0,
       "g": 0,
       "b": 0

--- a/src/preset-themes/010.json
+++ b/src/preset-themes/010.json
@@ -7,17 +7,17 @@
       "b": 252,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 0,
       "g": 0,
       "b": 0
     },
-    "accentcolor": {
+    "frame": {
       "r": 215,
       "g": 234,
       "b": 234
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 0,
       "g": 0,
       "b": 0

--- a/src/preset-themes/011.json
+++ b/src/preset-themes/011.json
@@ -7,7 +7,7 @@
       "b": 235,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 88,
       "g": 151,
       "b": 223

--- a/src/preset-themes/011.json
+++ b/src/preset-themes/011.json
@@ -7,17 +7,17 @@
       "b": 235,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 88,
       "g": 151,
       "b": 223
     },
-    "accentcolor": {
+    "frame": {
       "r": 201,
       "g": 212,
       "b": 222
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 240,
       "g": 140,
       "b": 40

--- a/src/preset-themes/012.json
+++ b/src/preset-themes/012.json
@@ -7,17 +7,17 @@
       "b": 240,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 214,
       "g": 81,
       "b": 109
     },
-    "accentcolor": {
+    "frame": {
       "r": 73,
       "g": 153,
       "b": 201
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 248,
       "g": 248,
       "b": 248

--- a/src/preset-themes/012.json
+++ b/src/preset-themes/012.json
@@ -7,7 +7,7 @@
       "b": 240,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 214,
       "g": 81,
       "b": 109

--- a/src/preset-themes/013.json
+++ b/src/preset-themes/013.json
@@ -7,7 +7,7 @@
       "b": 239,
       "a": 0.41
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 255,
       "g": 138,
       "b": 163

--- a/src/preset-themes/013.json
+++ b/src/preset-themes/013.json
@@ -7,17 +7,17 @@
       "b": 239,
       "a": 0.41
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 255,
       "g": 138,
       "b": 163
     },
-    "accentcolor": {
+    "frame": {
       "r": 60,
       "g": 105,
       "b": 134
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 255,
       "g": 138,
       "b": 163

--- a/src/preset-themes/014.json
+++ b/src/preset-themes/014.json
@@ -7,17 +7,17 @@
       "b": 251,
       "a": 0.86
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 102,
       "g": 102,
       "b": 194
     },
-    "accentcolor": {
+    "frame": {
       "r": 247,
       "g": 212,
       "b": 212
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 104,
       "g": 104,
       "b": 196

--- a/src/preset-themes/014.json
+++ b/src/preset-themes/014.json
@@ -7,7 +7,7 @@
       "b": 251,
       "a": 0.86
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 102,
       "g": 102,
       "b": 194

--- a/src/preset-themes/015.json
+++ b/src/preset-themes/015.json
@@ -7,17 +7,17 @@
       "b": 45,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 143,
       "g": 143,
       "b": 143
     },
-    "accentcolor": {
+    "frame": {
       "r": 0,
       "g": 0,
       "b": 0
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 140,
       "g": 140,
       "b": 140

--- a/src/preset-themes/015.json
+++ b/src/preset-themes/015.json
@@ -7,7 +7,7 @@
       "b": 45,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 143,
       "g": 143,
       "b": 143

--- a/src/preset-themes/016.json
+++ b/src/preset-themes/016.json
@@ -7,17 +7,17 @@
       "b": 253,
       "a": 0.86
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 255,
       "g": 255,
       "b": 255
     },
-    "accentcolor": {
+    "frame": {
       "r": 220,
       "g": 203,
       "b": 216
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 0,
       "g": 0,
       "b": 0

--- a/src/preset-themes/016.json
+++ b/src/preset-themes/016.json
@@ -7,7 +7,7 @@
       "b": 253,
       "a": 0.86
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 255,
       "g": 255,
       "b": 255

--- a/src/preset-themes/017.json
+++ b/src/preset-themes/017.json
@@ -7,17 +7,17 @@
       "b": 246,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 255,
       "g": 138,
       "b": 163
     },
-    "accentcolor": {
+    "frame": {
       "r": 233,
       "g": 225,
       "b": 234
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 255,
       "g": 138,
       "b": 163

--- a/src/preset-themes/017.json
+++ b/src/preset-themes/017.json
@@ -7,7 +7,7 @@
       "b": 246,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 255,
       "g": 138,
       "b": 163

--- a/src/preset-themes/018.json
+++ b/src/preset-themes/018.json
@@ -7,17 +7,17 @@
       "b": 253,
       "a": 0.77
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 255,
       "g": 255,
       "b": 255
     },
-    "accentcolor": {
+    "frame": {
       "r": 225,
       "g": 86,
       "b": 193
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 0,
       "g": 15,
       "b": 1

--- a/src/preset-themes/018.json
+++ b/src/preset-themes/018.json
@@ -7,7 +7,7 @@
       "b": 253,
       "a": 0.77
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 255,
       "g": 255,
       "b": 255

--- a/src/preset-themes/019.json
+++ b/src/preset-themes/019.json
@@ -7,7 +7,7 @@
       "b": 255,
       "a": 0.64
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 0,
       "g": 187,
       "b": 255

--- a/src/preset-themes/019.json
+++ b/src/preset-themes/019.json
@@ -7,17 +7,17 @@
       "b": 255,
       "a": 0.64
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 0,
       "g": 187,
       "b": 255
     },
-    "accentcolor": {
+    "frame": {
       "r": 221,
       "g": 249,
       "b": 118
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 0,
       "g": 187,
       "b": 255

--- a/src/preset-themes/020.json
+++ b/src/preset-themes/020.json
@@ -7,17 +7,17 @@
       "b": 230,
       "a": 0.7
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 28,
       "g": 71,
       "b": 227
     },
-    "accentcolor": {
+    "frame": {
       "r": 162,
       "g": 234,
       "b": 235
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 0,
       "g": 15,
       "b": 1

--- a/src/preset-themes/020.json
+++ b/src/preset-themes/020.json
@@ -7,7 +7,7 @@
       "b": 230,
       "a": 0.7
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 28,
       "g": 71,
       "b": 227

--- a/src/preset-themes/021.json
+++ b/src/preset-themes/021.json
@@ -7,17 +7,17 @@
       "b": 255,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 255,
       "g": 0,
       "b": 0
     },
-    "accentcolor": {
+    "frame": {
       "r": 255,
       "g": 255,
       "b": 255
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 255,
       "g": 0,
       "b": 0

--- a/src/preset-themes/021.json
+++ b/src/preset-themes/021.json
@@ -7,7 +7,7 @@
       "b": 255,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 255,
       "g": 0,
       "b": 0

--- a/src/preset-themes/022.json
+++ b/src/preset-themes/022.json
@@ -7,17 +7,17 @@
       "b": 255,
       "a": 0.49
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 222,
       "g": 18,
       "b": 181
     },
-    "accentcolor": {
+    "frame": {
       "r": 80,
       "g": 226,
       "b": 192
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 185,
       "g": 17,
       "b": 223

--- a/src/preset-themes/022.json
+++ b/src/preset-themes/022.json
@@ -7,7 +7,7 @@
       "b": 255,
       "a": 0.49
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 222,
       "g": 18,
       "b": 181

--- a/src/preset-themes/default.json
+++ b/src/preset-themes/default.json
@@ -7,17 +7,17 @@
       "b": 239,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 248,
       "g": 112,
       "b": 140
     },
-    "accentcolor": {
+    "frame": {
       "r": 142,
       "g": 179,
       "b": 201
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 255,
       "g": 255,
       "b": 255

--- a/src/preset-themes/default.json
+++ b/src/preset-themes/default.json
@@ -7,7 +7,7 @@
       "b": 239,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 248,
       "g": 112,
       "b": 140

--- a/src/preset-themes/hotdog.json
+++ b/src/preset-themes/hotdog.json
@@ -7,17 +7,17 @@
       "b": 0,
       "a": 1
     },
-    "toolbar_text": {
+    "bookmark_text": {
       "r": 0,
       "g": 0,
       "b": 0
     },
-    "accentcolor": {
+    "frame": {
       "r": 255,
       "g": 0,
       "b": 0
     },
-    "textcolor": {
+    "tab_background_text": {
       "r": 0,
       "g": 0,
       "b": 0

--- a/src/preset-themes/hotdog.json
+++ b/src/preset-themes/hotdog.json
@@ -7,7 +7,7 @@
       "b": 0,
       "a": 1
     },
-    "bookmark_text": {
+    "toolbar_text": {
       "r": 0,
       "g": 0,
       "b": 0

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -51,11 +51,29 @@ const urlEncodeTheme = ({ hasCustomBackgrounds = false, theme }) => {
 
 const urlDecodeTheme = themeString => jsonCodec.decompress(themeString);
 
-const postMessage = (type, data = {}) =>
+const postMessage = (type, data = {}) => {
+  // Add old lwt aliases for compatibility with Firefox Color 2.1.4 and earlier
+  // (new Firefox Color versions will remove these properties before applying it,
+  // while on older version it would make the theme to still look as expected).
+  if (type === "setTheme" & data.theme) {
+    const {theme} = data;
+    if (theme.colors) {
+      if (!theme.colors.accentcolor && theme.colors.frame) {
+        theme.colors.accentcolor = theme.colors.frame;
+      }
+      if (!theme.colors.textcolor && theme.colors.tab_background_text) {
+        theme.colors.textcolor = theme.colors.tab_background_text;
+      }
+    }
+    if (theme.images && !theme.images.headerURL && theme.images.theme_frame) {
+      theme.images.headerURL = theme.images.theme_frame;
+    }
+  }
   window.postMessage(
     { ...data, type, channel: `${CHANNEL_NAME}-extension` },
     "*"
   );
+};
 
 const composeEnhancers = composeWithDevTools({});
 

--- a/src/web/lib/components/AppBackground/index.js
+++ b/src/web/lib/components/AppBackground/index.js
@@ -14,7 +14,7 @@ export const AppBackground = ({ theme }) => {
       colors[key] = colorToCSS(theme.colors[key]);
     });
     style.background = `linear-gradient(150deg, ${colors.toolbar} 22.5%, ${
-      colors.accentcolor
+      colors.frame
     } 68.1%)`;
   }
 

--- a/src/web/lib/components/Browser/index.js
+++ b/src/web/lib/components/Browser/index.js
@@ -61,7 +61,7 @@ const Browser = ({
           style={{
             transition: selectSettings.transition,
             outline:
-              selectedColor === "accentcolor"
+              selectedColor === "frame"
                 ? selectSettings.active
                 : selectSettings.inactive
           }}

--- a/src/web/lib/components/BrowserChrome/index.js
+++ b/src/web/lib/components/BrowserChrome/index.js
@@ -18,7 +18,7 @@ const BrowserChrome = ({
         backgroundImage: !themeHasCustomBackgrounds
           ? headerBackgroundImage
           : null,
-        backgroundColor: colors.accentcolor
+        backgroundColor: colors.frame
       }}
     >
       {customImages.map((image, index) => {

--- a/src/web/lib/components/BrowserTabs/index.js
+++ b/src/web/lib/components/BrowserTabs/index.js
@@ -23,7 +23,7 @@ const BrowserTabs = ({
               className={`browser-tabs__tab ${isTabSelected}`}
               style={{
                 backgroundColor: isTabSelected ? colors.toolbar : "transparent",
-                color: isTabSelected ? colors.toolbar_text : colors.textcolor,
+                color: isTabSelected ? colors.bookmark_text : colors.tab_background_text,
                 boxShadow: isTabSelected ? `0 3px ${colors.tab_line} inset` : ""
               }}
             >
@@ -62,8 +62,8 @@ const BrowserTabs = ({
                   style={{
                     padding: "3px",
                     outline:
-                      (isTabSelected && selectedColor === "toolbar_text") ||
-                      (!isTabSelected && selectedColor === "textcolor")
+                      (isTabSelected && selectedColor === "bookmark_text") ||
+                      (!isTabSelected && selectedColor === "tab_background_text")
                         ? selectSettings.active
                         : selectSettings.inactive
                   }}
@@ -72,8 +72,8 @@ const BrowserTabs = ({
                     className="browser-tabs__title"
                     style={{
                       backgroundColor: isTabSelected
-                        ? colors.toolbar_text
-                        : colors.textcolor
+                        ? colors.bookmark_text
+                        : colors.tab_background_text
                     }}
                   />
                 </span>

--- a/src/web/lib/components/BrowserTabs/index.js
+++ b/src/web/lib/components/BrowserTabs/index.js
@@ -23,7 +23,7 @@ const BrowserTabs = ({
               className={`browser-tabs__tab ${isTabSelected}`}
               style={{
                 backgroundColor: isTabSelected ? colors.toolbar : "transparent",
-                color: isTabSelected ? colors.bookmark_text : colors.tab_background_text,
+                color: isTabSelected ? colors.toolbar_text : colors.tab_background_text,
                 boxShadow: isTabSelected ? `0 3px ${colors.tab_line} inset` : ""
               }}
             >
@@ -62,7 +62,7 @@ const BrowserTabs = ({
                   style={{
                     padding: "3px",
                     outline:
-                      (isTabSelected && selectedColor === "bookmark_text") ||
+                      (isTabSelected && selectedColor === "toolbar_text") ||
                       (!isTabSelected && selectedColor === "tab_background_text")
                         ? selectSettings.active
                         : selectSettings.inactive
@@ -72,7 +72,7 @@ const BrowserTabs = ({
                     className="browser-tabs__title"
                     style={{
                       backgroundColor: isTabSelected
-                        ? colors.bookmark_text
+                        ? colors.toolbar_text
                         : colors.tab_background_text
                     }}
                   />

--- a/src/web/lib/components/BrowserTools/index.js
+++ b/src/web/lib/components/BrowserTools/index.js
@@ -11,7 +11,7 @@ export const BrowserTools = ({
   selectSettings,
   selectedColor = null
 }) => {
-  const Button = ({ name, asset = false, colorName = "bookmark_text" }) => (
+  const Button = ({ name, asset = false, colorName = "toolbar_text" }) => (
     <span
       className="browser-tools__button"
       style={{

--- a/src/web/lib/components/BrowserTools/index.js
+++ b/src/web/lib/components/BrowserTools/index.js
@@ -11,7 +11,7 @@ export const BrowserTools = ({
   selectSettings,
   selectedColor = null
 }) => {
-  const Button = ({ name, asset = false, colorName = "toolbar_text" }) => (
+  const Button = ({ name, asset = false, colorName = "bookmark_text" }) => (
     <span
       className="browser-tools__button"
       style={{

--- a/src/web/lib/components/ThemePatternPicker/index.js
+++ b/src/web/lib/components/ThemePatternPicker/index.js
@@ -7,7 +7,7 @@ import { bgImages } from "../../../../lib/assets";
 
 console.log(bgImages);
 
-const Pattern = ({ src, backgroundId, active, setBackground, accentcolor }) => (
+const Pattern = ({ src, backgroundId, active, setBackground, frame }) => (
   <div>
     <input
       id={`theme-pattern-${backgroundId}`}
@@ -25,7 +25,7 @@ const Pattern = ({ src, backgroundId, active, setBackground, accentcolor }) => (
         htmlFor={`theme-pattern-${backgroundId}`}
         className="theme-pattern-picker__color"
         style={{
-          backgroundColor: accentcolor,
+          backgroundColor: frame,
           backgroundImage: `url(${bgImages(src)})`
         }}
       />
@@ -57,7 +57,7 @@ class ThemeBackgroundPicker extends React.Component {
 
   render() {
     const { theme, setBackground } = this.props;
-    const accentcolor = colorToCSS(theme.colors.accentcolor);
+    const frame = colorToCSS(theme.colors.frame);
     return (
       <div className="theme-pattern-picker">
         <p>Pick a pattern for your theme...</p>
@@ -68,7 +68,7 @@ class ThemeBackgroundPicker extends React.Component {
               {...{
                 src,
                 backgroundId,
-                accentcolor,
+                frame,
                 setBackground,
                 active: theme.images.additional_backgrounds[0] === src
               }}

--- a/src/web/lib/export.js
+++ b/src/web/lib/export.js
@@ -24,8 +24,8 @@ export default function performThemeExport({
   if (theme.images) {
     const { images } = theme;
     const { additional_backgrounds } = images;
-    if (images.headerURL) {
-      images.headerURL = addImage(zip, images.headerURL);
+    if (images.theme_frame) {
+      images.theme_frame = addImage(zip, images.theme_frame);
     }
     if (additional_backgrounds) {
       for (let idx = 0; idx < additional_backgrounds.length; idx++) {


### PR DESCRIPTION
This PR includes and supersedes #803 
Besides the change already included in #803, this PR also brings back toolbar_text (as it is not on the deprecation path anymore) and remove the changes to the package.json file (because they are unrelated to this fix and they can be applied in separate PRs).

NOTE: the theme normalization happens on the companion website and so to fully fix the incompatibility between Firefox Color and Firefox 70 we need to both publish the new version of the xpi and update the color.firefox.com website.

Fixes #763