### PR TITLE
I841 updating addon url / install text for default/dev only-wip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     docker:
       - image: circleci/node:8.11.2@sha256:495a13db597b5306f05ae728489fedb9faa4defbac24ca0e00e8cc1eca95396d
     environment:
-      ADDON_URL: https://addons.mozilla.org/firefox/downloads/latest/firefox-color/firefox-color-latest.xpi
+      ADDON_URL: https://addons.mozilla.org/en-US/firefox/addon/firefox-color/
     working_directory: ~/FirefoxColor
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     docker:
       - image: circleci/node:8.11.2@sha256:495a13db597b5306f05ae728489fedb9faa4defbac24ca0e00e8cc1eca95396d
     environment:
-      ADDON_URL: https://addons.mozilla.org/en-US/firefox/addon/firefox-color/
+      ADDON_URL: https://addons.mozilla.org/firefox/addon/firefox-color/
     working_directory: ~/FirefoxColor
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ on this repo. Production release consists of pushing to the `production` branch.
 
 The script `npm run release:dev` in `package.json` takes care of the following:
 
-* Set `ADDON_URL` and `SITE_URL` vars to point at mozilla.github.io/FirefoxColor
+* Sets the `SITE_URL` var to point at mozilla.github.io/FirefoxColor
+
+* Sets the `ADDON_URL` var to point at https://addons-dev.allizom.org/firefox/addon/firefox-color/
 
 * Build the site
 
@@ -95,6 +97,15 @@ Every release requires a version bump, because version numbers cannot be reused.
 | Development | [development](https://github.com/mozilla/FirefoxColor/tree/development) | https://mozilla.github.io/FirefoxColor/ |
 | Stage       | [stage](https://github.com/mozilla/FirefoxColor/tree/stage)             | https://color.stage.mozaws.net/         |
 | Production  | [production](https://github.com/mozilla/FirefoxColor/tree/production)   | https://color.firefox.com/              |
+
+## UI to install the addon:
+
+* Coming from AMO
+  - The user clicks on the "Install" button and after granting permissions, a new tab opens to the addon's home page.
+
+* Coming from the addon's home page:
+  - The user can click on the "Get Firefox Color" button which will link the user back the AMO site in the respective environment.
+
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:js": "mocha --require src/lib/test-setup.js --recursive \"src/**/*-test.js\"",
     "deploy": "gh-pages -x -d build/web -r \"https://$GH_TOKEN@github.com/mozilla/FirefoxColor.git\"",
     "release:base": "npm-run-all clean build:web sign && mv addon.xpi build/web && npm run deploy",
-    "release:dev": "cross-env ADDON_URL='https://mozilla.github.io/FirefoxColor/addon.xpi' SITE_URL='https://mozilla.github.io/FirefoxColor/' SITE_ID=github npm run release:base"
+    "release:dev": "cross-env ADDON_URL='https://addons-dev.allizom.org/en-US/firefox/addon/firefox-color/' SITE_URL='https://mozilla.github.io/FirefoxColor/' SITE_ID=github npm run release:base"
   },
   "engines": {
     "node": ">=8.9.4"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:js": "mocha --require src/lib/test-setup.js --recursive \"src/**/*-test.js\"",
     "deploy": "gh-pages -x -d build/web -r \"https://$GH_TOKEN@github.com/mozilla/FirefoxColor.git\"",
     "release:base": "npm-run-all clean build:web sign && mv addon.xpi build/web && npm run deploy",
-    "release:dev": "cross-env ADDON_URL='https://addons-dev.allizom.org/en-US/firefox/addon/firefox-color/' SITE_URL='https://mozilla.github.io/FirefoxColor/' SITE_ID=github npm run release:base"
+    "release:dev": "cross-env ADDON_URL='https://addons-dev.allizom.org/firefox/addon/firefox-color/' SITE_URL='https://mozilla.github.io/FirefoxColor/' SITE_ID=github npm run release:base"
   },
   "engines": {
     "node": ">=8.9.4"

--- a/src/web/lib/components/Banner/index.js
+++ b/src/web/lib/components/Banner/index.js
@@ -16,7 +16,7 @@ export const Banner = ({ isFirefox, addonUrl }) => {
               href={addonUrl}
               className="banner__button"
             >
-              Install Firefox Color
+              Get Firefox Color
             </a>
           </Fragment>
         )}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -20,7 +20,7 @@ const isDev = nodeEnv === "development";
 
 const defaultEnv = {
   NODE_ENV: nodeEnv,
-  ADDON_URL: "https://addons.mozilla.org/en-US/firefox/addon/firefox-color/",
+  ADDON_URL: "https://addons.mozilla.org/firefox/addon/firefox-color/",
   SITE_URL: siteUrl,
   DOWNLOAD_FIREFOX_UTM_SOURCE: downloadFirefoxUtmSource,
   LOADER_DELAY_PERIOD: "2000"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -20,7 +20,7 @@ const isDev = nodeEnv === "development";
 
 const defaultEnv = {
   NODE_ENV: nodeEnv,
-  ADDON_URL: "addon.xpi",
+  ADDON_URL: "https://addons.mozilla.org/en-US/firefox/addon/firefox-color/",
   SITE_URL: siteUrl,
   DOWNLOAD_FIREFOX_UTM_SOURCE: downloadFirefoxUtmSource,
   LOADER_DELAY_PERIOD: "2000"
@@ -65,7 +65,7 @@ const webpackConfig = {
       cacheGroups: {
         vendor: {
           test: /[\\/]node_modules[\\/]/,
-          priority: 0          
+          priority: 0
         }
       }
     }


### PR DESCRIPTION
hey @caitmuenster, so I’ve updated the addon url in this PR. I think this might be a little difficult to test locally (since it links out) so my thinking is if we could add the FFColor addon to AMO dev (I might need access to this or help adding this addon here - to AMO dev), we could test out the flow there first. note: I think we would need to also adjust some config settings to allow the dev install there.  maybe @Rob--W can weigh in or advise on this:)

In theory though, you can also see the flow by starting at the AMO site (since this green button will link directly here) and I believe it already seems do what you are asking for here. I know we were going back and forth on this a little bit last week so let me know:)