### PR TITLE
I849 cking for unused imgs in themes on tab close

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -45,8 +45,8 @@ const urlEncodeTheme = ({ hasCustomBackgrounds = false, theme }) => {
   return hasCustomBackgrounds
     ? Promise.resolve(baseUrl)
     : jsonCodec
-        .compress(normalizeTheme(theme))
-        .then(value => `${baseUrl}?theme=${value}`);
+      .compress(normalizeTheme(theme))
+      .then(value => `${baseUrl}?theme=${value}`);
 };
 
 const urlDecodeTheme = themeString => jsonCodec.decompress(themeString);
@@ -58,7 +58,7 @@ const postMessage = (type, data = {}) => {
   if (type === "setTheme" && data.theme) {
     // Deep-clone to avoid mutating the input parameter.
     data = JSON.parse(JSON.stringify(data));
-    const {theme} = data;
+    const { theme } = data;
     if (theme.colors) {
       if (!theme.colors.accentcolor && theme.colors.frame) {
         theme.colors.accentcolor = theme.colors.frame;
@@ -100,6 +100,44 @@ window.addEventListener("popstate", ({ state: { theme } }) =>
     }
   })
 );
+
+window.addEventListener("beforeunload", (e) => {
+  const state = store.getState();
+  const imageNames = backgrounds =>
+    backgrounds.map(background => background.name);
+  const currentImages = new Set(
+    imageNames(selectors.themeCustomBackgrounds(state))
+  );
+  const localStorageKeys = Object.keys(localStorage);
+  const localStorageEntries = Object.entries(localStorage);
+
+  let themeImages = [];
+
+  // Search for any images that are used in themes.
+  localStorageEntries.forEach((_, index) => {
+    if (localStorageKeys[index].startsWith("THEME")) {
+      const item = localStorage.getItem(localStorageKeys[index]);
+      const itemParsed = JSON.parse(item);
+      if (!itemParsed.theme.images.custom_backgrounds) return;
+      itemParsed.theme.images.custom_backgrounds.map(bgs => {
+        if (localStorageKeys.includes(`IMAGE-${bgs.name}`)) {
+          themeImages.push(bgs.name);
+        }
+      });
+    }
+  });
+
+  // Remove duplicates images that come up.
+  const themeImagesSet = new Set(themeImages);
+
+  // Remove images that are not used in saved themes or are currently in the custom background
+  // view.
+  const toDelete = Object.keys(selectors.themeCustomImages(state)).filter(name => {
+    return !currentImages.has(name) && !themeImagesSet.has(name);
+  });
+
+  store.dispatch(actions.images.deleteImages(toDelete));
+});
 
 window.addEventListener("message", ({ source, data: message }) => {
   if (


### PR DESCRIPTION
fixes #849

When the tab is closed, this will do an additional scan to see what images that are in local storage are being used in the saved themes. If it's not used at that point, it will be removed.