### PR TITLE
I886 adding custom bgs empty default

### DIFF
--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -11,7 +11,7 @@ const defaultTheme = presetThemesContext("./default.json");
 
 const IMAGE_PROPS = ["name", "tiling", "alignment"];
 
-export const themesEqual = (themeA, themeB) => {
+export const themesEqual = (themeA, themeB) => {  
   if (!!themeA !== !!themeB) {
     return false;
   }
@@ -33,17 +33,8 @@ export const themesEqual = (themeA, themeB) => {
     }
   }
 
-  if (themeA.images && !themeA.images.custom_backgrounds) {
-      themeA.images.custom_backgrounds = [];
-  }
-
-  if (themeB.images && !themeB.images.custom_backgrounds) {
-      themeB.images.custom_backgrounds = [];
-  }
-
-    const imagesA = themeA.images && themeA.images.custom_backgrounds || [];
-    const imagesB = themeB.images && themeB.images.custom_backgrounds || [] ;
-
+  const imagesA = themeA.images && themeA.images.custom_backgrounds || [];
+  const imagesB = themeB.images && themeB.images.custom_backgrounds || [] ;
     if (imagesA.length !== imagesB.length) {
       return false;
     }

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -40,17 +40,10 @@ export const themesEqual = (themeA, themeB) => {
   if (themeB.images && !themeB.images.custom_backgrounds) {
       themeB.images.custom_backgrounds = [];
   }
-  
-  const hasCustomImagesA =
-    "images" in themeA && "custom_backgrounds" in themeA.images;
-  const hasCustomImagesB =
-    "images" in themeB && "custom_backgrounds" in themeB.images;
-  if (hasCustomImagesA !== hasCustomImagesB) {
-    return false;
-  }
-  if (hasCustomImagesA && hasCustomImagesB) {
-    const imagesA = themeA.images.custom_backgrounds;
-    const imagesB = themeB.images.custom_backgrounds;
+
+    const imagesA = themeA.images && themeA.images.custom_backgrounds || [];
+    const imagesB = themeB.images && themeB.images.custom_backgrounds || [] ;
+
     if (imagesA.length !== imagesB.length) {
       return false;
     }
@@ -64,7 +57,6 @@ export const themesEqual = (themeA, themeB) => {
         }
       }
     }
-  }
 
   // TODO: Skipping title equality, because user themes don't have titles yet.
 

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -33,6 +33,14 @@ export const themesEqual = (themeA, themeB) => {
     }
   }
 
+  if (themeA.images && !themeA.images.custom_backgrounds) {
+      themeA.images.custom_backgrounds = [];
+  }
+
+  if (themeB.images && !themeB.images.custom_backgrounds) {
+      themeB.images.custom_backgrounds = [];
+  }
+  
   const hasCustomImagesA =
     "images" in themeA && "custom_backgrounds" in themeA.images;
   const hasCustomImagesB =

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -35,19 +35,19 @@ export const themesEqual = (themeA, themeB) => {
 
   const imagesA = themeA.images && themeA.images.custom_backgrounds || [];
   const imagesB = themeB.images && themeB.images.custom_backgrounds || [] ;
-    if (imagesA.length !== imagesB.length) {
-      return false;
-    }
-    for (let idx = 0; idx < imagesA.length; idx++) {
-      for (let propIdx = 0; propIdx < IMAGE_PROPS.length; propIdx++) {
-        if (
-          imagesA[idx][IMAGE_PROPS[propIdx]] !==
-          imagesB[idx][IMAGE_PROPS[propIdx]]
-        ) {
-          return false;
-        }
+  if (imagesA.length !== imagesB.length) {
+    return false;
+  }
+  for (let idx = 0; idx < imagesA.length; idx++) {
+    for (let propIdx = 0; propIdx < IMAGE_PROPS.length; propIdx++) {
+      if (
+        imagesA[idx][IMAGE_PROPS[propIdx]] !==
+        imagesB[idx][IMAGE_PROPS[propIdx]]
+      ) {
+        return false;
       }
     }
+  }
 
   // TODO: Skipping title equality, because user themes don't have titles yet.
 

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -11,7 +11,7 @@ const defaultTheme = presetThemesContext("./default.json");
 
 const IMAGE_PROPS = ["name", "tiling", "alignment"];
 
-export const themesEqual = (themeA, themeB) => {  
+export const themesEqual = (themeA, themeB) => {
   if (!!themeA !== !!themeB) {
     return false;
   }

--- a/src/preset-themes/default.json
+++ b/src/preset-themes/default.json
@@ -50,6 +50,9 @@
     }
   },
   "images": {
-    "additional_backgrounds": ["./bg-009.svg"]
+    "additional_backgrounds": [
+      "./bg-009.svg"
+    ],
+    "custom_backgrounds": []
   }
 }

--- a/src/preset-themes/default.json
+++ b/src/preset-themes/default.json
@@ -52,7 +52,6 @@
   "images": {
     "additional_backgrounds": [
       "./bg-009.svg"
-    ],
-    "custom_backgrounds": []
+    ]
   }
 }

--- a/src/preset-themes/default.json
+++ b/src/preset-themes/default.json
@@ -50,8 +50,6 @@
     }
   },
   "images": {
-    "additional_backgrounds": [
-      "./bg-009.svg"
-    ]
+    "additional_backgrounds": ["./bg-009.svg"]
   }
 }

--- a/src/web/lib/components/AppHeader/index.js
+++ b/src/web/lib/components/AppHeader/index.js
@@ -43,7 +43,7 @@ export const AppHeader = props => {
     if (shouldUpdate) {
       syncImages();
     }
-  }, [props.themeCustomBackgrounds]);
+  }, [shouldUpdate]);
 
 
   const handleExportClick = () => {
@@ -84,6 +84,7 @@ export const AppHeader = props => {
     if (toDelete.length) {
       props.deleteImages(toDelete);
     }
+    setUpdate(false);
   };
 
   const headerButton = (


### PR DESCRIPTION
fixes #886 

It seems that random themes do not have a custom_backgrounds property which makes sense but in redux the present theme would show this as an empty custom_backgrounds array so it was showing as modified since these are themes are technically different. I do not believe that preset themes has this issue so I do realize there is some different implementation but imo it is better to have this default value. 

Anyway, I need to do more testing to make sure there are no regressions but I believe this fixes the issue. 

seems it also fixes #877 🎉 (but will test a bit more :)

