### PR TITLE
Fixes #335: Fix autoscroll wrongly activated

### DIFF
--- a/src/web/lib/components/AppFooter/index.js
+++ b/src/web/lib/components/AppFooter/index.js
@@ -8,7 +8,8 @@ import iconTwitter from "./twitter-logo.svg";
 import "./index.scss";
 
 export const AppFooter = ({ hasExtension, setDisplayLegalModal }) => {
-  const toggleModal = name => {
+  const toggleModal = (e, name) => {
+    e.preventDefault();
     setDisplayLegalModal({ display: true });
   };
   return (
@@ -30,14 +31,14 @@ export const AppFooter = ({ hasExtension, setDisplayLegalModal }) => {
         <a
           className="app-footer__legal-link"
           href="#"
-          onClick={() => toggleModal("Privacy")}
+          onClick={(e) => toggleModal(e, "Privacy")}
         >
           Privacy
         </a>
         <a
           className="app-footer__legal-link"
           href="#"
-          onClick={() => toggleModal("Terms")}
+          onClick={(e) => toggleModal(e, "Terms")}
         >
           Terms
         </a>


### PR DESCRIPTION
@Rob--W, I was able to install the project by deleting the node_modules and running npm install again. I tried your suggestion of using `e.preventDefault()` but it didn't work. I also tried adding `return false` to the click functions which also didn't work.

I then now replaced `href='#'` with `href='javascript:void(0)`. This however had the effect of opening a new tab when the middle scroll button is clicked.

Alternatively, I replaced the anchor tags with a span tag so that a new page isn't opened on middle scroll click. That is, nothing happens when the middle scroll button is clicked.

I am using a windows OS and do not know if the resolution has the same effect on Linux and Mac