### PR TITLE
chore: bump version to 2.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firefoxcolor",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firefoxcolor",
   "description": "Theming experiment for Firefox Quantum and beyond.",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "author": "Les Orchard <me@lmorchard.com>",
   "contributors": [
     "John Gruen <john.gruen@gmail.com>"


### PR DESCRIPTION
Bump version for a new release, mainly to publish the fix from #944 (fixes #942, + #944, #945).

Most of the other commits since the last change were overdue dependency updates.