### PR TITLE
Fixes #334: remove firstRun from query string on onboarding dismiss

### DIFF
--- a/src/web/lib/components/Onboarding/index.js
+++ b/src/web/lib/components/Onboarding/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 
 import classnames from "classnames";
+import queryString from "query-string";
 
 import "./index.scss";
 import LogoIcon from "./LogoIcon";
@@ -28,6 +29,16 @@ export default class Onboarding extends React.Component {
 
   handleDismiss = e => {
     if (e.target.classList.contains("dismissable")) {
+      const params = queryString.parse(window.location.search);
+      const pathname = window.location.pathname;
+
+      delete params.firstRun;
+      let stringifiedParams = queryString.stringify(params);
+      stringifiedParams = `${stringifiedParams && "?"}${stringifiedParams}`;
+
+      const newUrl = `${pathname}${stringifiedParams}`;
+      window.history.replaceState(window.history.state, "", newUrl);
+
       this.setState({ isDisplayed: false });
     }
   };


### PR DESCRIPTION
The cause of the redisplay was the URL parameter ```firstRun``` which persists after a refresh. To solve it, when handling the dismiss of Onboarding, it will remove the ```firstRun``` parameter from the URL.

Fixes #334 