### PR TITLE
Fixes #883: set .browser min-height: 700px

### DIFF
--- a/src/web/lib/components/App/index.scss
+++ b/src/web/lib/components/App/index.scss
@@ -15,7 +15,7 @@
 
   > .browser {
     grid-column: 2 / 3;
-    min-height: 600px;
+    min-height: 700px;
   }
 
   .app__firefox {


### PR DESCRIPTION
Fixes #883 
Fixes #952

I have increased the 'min-height' property for '.browser' in 'src/web/lib/components/App/index.scss' from 600px to 700px. This ensures that the popup never overlaps with the 'Raw Theme Data' bar or the color selector below. 

Before edit:

![600px](https://user-images.githubusercontent.com/52915849/106458310-04a7e380-64b2-11eb-93d3-3114b7e8392c.PNG)


After edit:


![700px](https://user-images.githubusercontent.com/52915849/106458335-0b365b00-64b2-11eb-872f-51eb5d3ef198.PNG)


