### PR TITLE
Fix scrolling overflow issue in Custom Colors tab and improve color naming

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -22,13 +22,13 @@ export const CUSTOM_BACKGROUND_ALLOWED_TYPES = [
 export const CUSTOM_BACKGROUND_DEFAULT_ALIGNMENT = "right top";
 
 export const colorLabels = {
-  toolbar: "Toolbar Color",
-  toolbar_text: "Toolbar Icons and Text",
-  frame: "Background Color",
-  tab_background_text: "Background Tab Text Color",
-  toolbar_field: "Search Bar Color",
-  toolbar_field_text: "Search Text",
-  tab_line: "Tab Highlight Color",
+  toolbar: "Toolbar",
+  toolbar_text: "Toolbar Icons And Text",
+  frame: "Background",
+  tab_background_text: "Background Tab Text",
+  toolbar_field: "Searchbar Background",
+  toolbar_field_text: "Searchbar Text",
+  tab_line: "Tab Highlight",
   popup: "Popup Background",
   popup_text: "Popup Text"
 };
@@ -39,7 +39,7 @@ export const advancedColorLabels = {
   frame_inactive: "Frame Inactive",
   icons_attention: "Icons Attention",
   icons: "Icons",
-  ntp_background: "New Tab Background Color",
+  ntp_background: "New Tab Background",
   ntp_text: "New Tab Text",
   popup_border: "Popup Border",
   popup_highlight_text: "Popup Highlight Text",

--- a/src/web/lib/components/ThemeBuilder/index.js
+++ b/src/web/lib/components/ThemeBuilder/index.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { DEBUG } from "../../../../lib/utils";
 
-import ThemeLogger from "../ThemeLogger";
 import PresetThemeSelector from "../PresetThemeSelector";
 import SavedThemeSelector from "../SavedThemeSelector";
 import ThemeBackgroundPicker from "../ThemeBackgroundPicker";
 import ThemeColorsEditor from "../ThemeColorsEditor";
+import ThemeLogger from "../ThemeLogger";
 
 import "./index.scss";
 
@@ -33,19 +33,19 @@ export const ThemeBuilder = props => {
 
   const tabList = [
     {
-      name: "Preset themes",
+      name: "Preset Themes",
       id: "preset-themes"
     },
     {
-      name: "Custom colors",
+      name: "Custom Colors",
       id: "colors"
     },
     {
-      name: "Advanced colors",
+      name: "Advanced Colors",
       id: "advanced-colors"
     },
     {
-      name: "Custom backgrounds",
+      name: "Custom Backgrounds",
       id: "backgrounds"
     }
   ];
@@ -199,7 +199,7 @@ export const ThemeBuilder = props => {
         id={`theme-builder-tab-content-${selectedTabId}`}
         aria-labelledby={`theme-builder-tab-${selectedTabId}`}
         className="theme-builder__content"
-        tabIndex="0"
+        tabIndex={0}
       >
         {renderThemingSection(selectedTabId)}
       </div>

--- a/src/web/lib/components/ThemeColorsEditor/index.js
+++ b/src/web/lib/components/ThemeColorsEditor/index.js
@@ -1,16 +1,16 @@
-import React from "react";
 import classnames from "classnames";
+import React from "react";
 import { SketchPicker } from "react-color";
 import onClickOutside from "react-onclickoutside";
+import semverCompare from "semver-compare";
 import {
-  colorsWithoutAlpha,
-  ESC,
+  advancedColorLabels,
   colorLabels,
-  advancedColorLabels
+  colorsWithoutAlpha,
+  ESC
 } from "../../../../lib/constants";
 import { colorToCSS } from "../../../../lib/themes";
 import StorageSpaceInformation from "../StorageSpaceInformation";
-import semverCompare from "semver-compare";
 
 import "./index.scss";
 
@@ -93,7 +93,7 @@ class ThemeColorsEditor extends React.Component {
 
     const selectedColorValue = colors[selectedColor];
     if (selectedColorValue) {
-      // Remember last selected color in case the user closes and re-opens the color picker.
+      // Remember last selected color incase the user closes and re-opens the color picker.
       this.lastSelectedColor = selectedColorValue;
     }
 

--- a/src/web/lib/components/ThemeColorsEditor/index.scss
+++ b/src/web/lib/components/ThemeColorsEditor/index.scss
@@ -13,21 +13,22 @@
 
 .theme-colors-editor__list {
   display: grid;
-  grid-template-rows: repeat(20, 44px);
+  grid-template-rows: repeat(1fr);
   grid-gap: $grid;
   grid-template-columns: 1fr 1fr;
   margin: 0 0 10px;
   padding: $grid * 4;
   position: relative;
   flex: 1 1 640px;
-  height: 350px;
-  overflow: auto;
+  height: 380px;
+  overflow: none;
 
   .theme-unit {
     align-items: center;
     display: flex;
     padding: 0 16px;
     cursor: pointer;
+    border-radius: 3px;
     transition: background 150ms;
 
     &:hover {


### PR DESCRIPTION
- Fixed scrolling issue on the **Custom Colors** tab, where unnecessary white-space was being shown. 
- Title-cased tab names.
- Improved **Custom** and **Advanced** color names, removing redundant instances of "color" from some.
- Added some border-radius to the list items, on hover.

Before:

![Untitled](https://user-images.githubusercontent.com/43590347/190881250-7d6c8d3a-65a7-4935-a1e9-95c72fe1d267.gif)

After:

<img width="1109" alt="Screen Shot 2022-09-17 at 9 12 58 PM" src="https://user-images.githubusercontent.com/43590347/190881349-7d094837-6def-4a33-96c2-56114fa09e56.png">
