### PR TITLE
Update tabpanel markup in the web ThemeBuilder component's index.js

### DIFF
--- a/src/web/lib/components/ThemeBuilder/index.js
+++ b/src/web/lib/components/ThemeBuilder/index.js
@@ -199,7 +199,7 @@ export const ThemeBuilder = props => {
         id={`theme-builder-tab-content-${selectedTabId}`}
         aria-labelledby={`theme-builder-tab-${selectedTabId}`}
         className="theme-builder__content"
-        tabIndex="0"
+        role="tabpanel"
       >
         {renderThemingSection(selectedTabId)}
       </div>


### PR DESCRIPTION
The tabpanel is not expected to be separately focusable with keyboard, but is expected to have a `role=tabpanel` to complete the tab list pattern, pet [ARIA Tabs design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) and [ARIA specs](https://w3c.github.io/aria/#tabpanel)