### PR TITLE
Update _common.scss to ensure the label for buttonPrimary is readable

### DIFF
--- a/src/web/lib/_common.scss
+++ b/src/web/lib/_common.scss
@@ -37,7 +37,7 @@ $grid: 4px;
 
 @mixin buttonPrimary {
   color: var(--white);
-  background-color: var(--green-60);
+  background-color: var(--green-70);
   box-shadow: 0 -3px 0 var(--grey-90-a10) inset;
 
   &:hover,


### PR DESCRIPTION
Current green background color is too light to be used for the white label text - it provides just 2.5:1 in color contrast while 3:1 is the bare minimum for large text and 4.5:1 or more is recommended. Changing the mixin to use a slightly darker gray keeps the bright visual appearance of the button while also providing the white label text with sufficient color contrast (4.47:1) for better readability and accessibility.